### PR TITLE
[#129956617] retry requests on failure

### DIFF
--- a/force/api.go
+++ b/force/api.go
@@ -27,6 +27,7 @@ type ForceApi struct {
 	apiMaxBatchSize        int64
 	logger                 ForceApiLogger
 	logPrefix              string
+	maxRetryRequests       int
 }
 
 type SObjectApiResponse struct {

--- a/force/force.go
+++ b/force/force.go
@@ -19,7 +19,7 @@ const (
 )
 
 func Create(version, clientId, clientSecret, userName, password, securityToken,
-	environment string) (*ForceApi, error) {
+	environment string, maxRetryRequests ...int) (*ForceApi, error) {
 	oauth := &forceOauth{
 		clientId:      clientId,
 		clientSecret:  clientSecret,
@@ -29,12 +29,17 @@ func Create(version, clientId, clientSecret, userName, password, securityToken,
 		environment:   environment,
 	}
 
+	maxRetries := 0
+	if len(maxRetryRequests) > 0 {
+		maxRetries = maxRetryRequests[0]
+	}
 	forceApi := &ForceApi{
 		apiResources:           make(map[string]string),
 		apiSObjects:            make(map[string]*SObjectMetaData),
 		apiSObjectDescriptions: make(map[string]*SObjectDescription),
 		apiVersion:             version,
 		oauth:                  oauth,
+		maxRetryRequests:       maxRetries,
 	}
 
 	// Init oauth

--- a/force/oauth.go
+++ b/force/oauth.go
@@ -88,7 +88,7 @@ func (oauth *forceOauth) Authenticate() error {
 	oauth.client = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
 	resp, err := oauth.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("Error sending authentication request: %v", err)
+		return fmt.Errorf("Error sending authentication request %v to %v! Error: %v", body, uri, err)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
retry only upto the max retries (configurable) and only
on "getsockopt: connection refused" failure
